### PR TITLE
feat(jaccard.js) implementation of constructor and strict mode options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# node-jaccard
+
+a lightweight, pure JS package to calculate the degree of similarity between strings. 
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# node-jaccard
+# compare-string | aka node-jaccard
 
-a lightweight, pure JS package to calculate the degree of similarity between strings. 
+a lightweight, pure JS implementation of [Jaccard's Index](https://en.wikipedia.org/wiki/Jaccard_index) to calculate the degree of similarity between strings. 
+
+
+
 

--- a/jaccard.js
+++ b/jaccard.js
@@ -22,8 +22,17 @@ const intersections = (_arr) => {
     return intersection.length;
 }
 
-module.exports = {
-    stringCompare([str1, str2]) {      
+
+
+module.exports = class {
+
+    constructor({ strict }) {
+        if(typeof strict !== "boolean") this.strict = true; else this.strict = strict;
+    }
+
+    compareString([str1, str2]) {      
+        if((typeof str1 === "string" || typeof str2 === "string") && this.strict) throw new Error("Cannot compare non-strings.")
+
         const firstFused = Array.from(split2(str1.replace(/\s+/g, ''))).concat(Array.from(split2(str2.replace(/\s+/g, ''))));
         const firstEval = intersections(firstFused) / unions(firstFused);
 
@@ -32,9 +41,5 @@ module.exports = {
 
         return (firstEval + secondEval) / 2;
     
-    },
-
-    stringMatch([str1, str2]) {
-
     }
 };

--- a/jaccard.js
+++ b/jaccard.js
@@ -22,6 +22,11 @@ const intersections = (_arr) => {
     return intersection.length;
 }
 
+const arrayCheck = (_arr) => {
+    for(x of _arr) {
+        if(!x || typeof x === "object") throw new Error("Could not parse an object.")
+    }
+}
 
 
 module.exports = class {

--- a/jaccard.js
+++ b/jaccard.js
@@ -45,6 +45,5 @@ module.exports = class {
         const secondEval = intersections(secondFused) / unions(secondFused);
 
         return (firstEval + secondEval) / 2;
-    
     }
 };

--- a/jaccard.js
+++ b/jaccard.js
@@ -24,7 +24,7 @@ const intersections = (_arr) => {
 
 const arrayCheck = (_arr) => {
     for(x of _arr) {
-        if(!x || typeof x === "object") throw new Error("Could not parse an object.")
+        if(!x || typeof x === "object" && this.strict) throw new Error("Could not parse an object."); else if(!x || typeof x === "object" && this.strict) return null;
     }
 }
 
@@ -36,7 +36,7 @@ module.exports = class {
     }
 
     compareString([str1, str2]) {      
-        if((typeof str1 === "string" || typeof str2 === "string") && this.strict) throw new Error("Cannot compare non-strings.")
+        if((typeof str1 === "string" || typeof str2 === "string") && this.strict) throw new Error("Cannot compare non-strings."); else if(typeof str1 === "string" || typeof str2 === "string" && !this.strict) return null;
 
         const firstFused = Array.from(split2(str1.replace(/\s+/g, ''))).concat(Array.from(split2(str2.replace(/\s+/g, ''))));
         const firstEval = intersections(firstFused) / unions(firstFused);

--- a/jaccard.js
+++ b/jaccard.js
@@ -23,7 +23,7 @@ const intersections = (_arr) => {
 }
 
 module.exports = {
-    compare([str1, str2]) {      
+    stringCompare([str1, str2]) {      
         const firstFused = Array.from(split2(str1.replace(/\s+/g, ''))).concat(Array.from(split2(str2.replace(/\s+/g, ''))));
         const firstEval = intersections(firstFused) / unions(firstFused);
 
@@ -32,5 +32,9 @@ module.exports = {
 
         return (firstEval + secondEval) / 2;
     
+    },
+
+    stringMatch([str1, str2]) {
+
     }
 };


### PR DESCRIPTION
**Changes**
This PR makes it so that the exported module is a class that must be instantiated with the constructor (`new`). It also adds the ability to configure how the library works by passing an object as a parameter.

a `strict` option is available, indicating if the library should throw an error if the matching sequence looks suspicious. if set to false, the library will simply return null.

**Why it should be merged**
gives the package much more flexibility and customizability

**Compatibility Issues**
You will no longer be able to directly call methods on the imported library, instead you must instantiate it with the constructor and pass your relevant options there

```js
const _compareString = require('compare-string')
const jaccard = new _compareString({ strict: true })
```

**Tests**
Simple importing and `console.log()`'ing the return value.
