### PR TITLE
feat: add LineDiff class

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 "use strict";
 const LCSHelper = require("./lib/lcs");
 const StringDiff = require("./lib/stringdiff");
-module.exports = {LCSHelper, StringDiff};
+const LineDiff = require("./lib/linediff");
+module.exports = {LCSHelper, StringDiff, LineDiff};

--- a/lib/linediff.js
+++ b/lib/linediff.js
@@ -83,6 +83,3 @@ class LineDiff {
         this.linesAdded = b.length - this.linelcs;
     }
 }
-
-const e = new LineDiff(fs.readFileSync("./test.txt", { encoding: "utf-8"}), fs.readFileSync("./test2.txt", { encoding: "utf-8" })).load({ignoreCase: true, ignoreWhitespace: true});
-e.calculate();

--- a/lib/linediff.js
+++ b/lib/linediff.js
@@ -53,8 +53,8 @@ class LineDiff {
             }
         }
         this.lcslen = this.dp[n][m];
-        this.linesDeleted = a.length - this.lcslen;
-        this.linesAdded = b.length - this.lcslen;
+        this.linesDeleted = linesA.length - this.lcslen;
+        this.linesAdded = linesB.length - this.lcslen;
 
 
         let i = n, j = m;
@@ -62,7 +62,7 @@ class LineDiff {
         const hashedLCS = [];
         while(i > 0 && j > 0) {
             if(astr[i - 1] === bstr[j - 1]) {
-                LCS.push(a[i - 1]);
+                LCS.push(linesA[i - 1]);
                 hashedLCS.push(astr[i - 1]);
                 i--;
                 j--;
@@ -73,12 +73,14 @@ class LineDiff {
             }
         }
         LCS.reverse();
+        hashedLCS.reverse();
         this.lcs = LCS;
         this.hashedlcs = hashedLCS;
     }
 
     _cleanse(str, options) {
         const res = str;
+        if(!options) return res;
         if(options.ignoreWhitespace) {
             res.replace(/\s/, "");
         }

--- a/lib/linediff.js
+++ b/lib/linediff.js
@@ -50,9 +50,9 @@ class LineDiff {
                 }
             }
         }
-        this.linelcs = this.dp[n][m];
-        this.linesDeleted = a.length - this.linelcs;
-        this.linesAdded = b.length - this.linelcs;
+        this.lcslen = this.dp[n][m];
+        this.linesDeleted = a.length - this.lcslen;
+        this.linesAdded = b.length - this.lcslen;
     }
 
     _cleanse(str, options) {

--- a/lib/linediff.js
+++ b/lib/linediff.js
@@ -7,6 +7,9 @@ class LineDiff {
     constructor(a, b, options) { //a: "source" ReadableStream (file), b: "target" ReadableStream (file), options: {ignoreCase: bool, ignoreWhitespace: bool}
         this.a = a;
         this.b = b;
+        this.source = a;
+        this.target = b;
+
         const linesA = this.a.split(/\r?\n/);
         const linesB = this.b.split(/\r?\n/);
         const astr = [];
@@ -37,9 +40,8 @@ class LineDiff {
         this.hashB = hashB;
 
 
-
-
         const n = this.astr.length;
+        const m = this.bstr.length;
         this.dp = [...Array(n+1)].map(() => Array(m+1).fill(0));
         for(let i = 1; i <= n; i++) {
             for(let j = 1; j <= m; j++) {
@@ -53,6 +55,26 @@ class LineDiff {
         this.lcslen = this.dp[n][m];
         this.linesDeleted = a.length - this.lcslen;
         this.linesAdded = b.length - this.lcslen;
+
+
+        let i = n, j = m;
+        const LCS = [];
+        const hashedLCS = [];
+        while(i > 0 && j > 0) {
+            if(astr[i - 1] === bstr[j - 1]) {
+                LCS.push(a[i - 1]);
+                hashedLCS.push(astr[i - 1]);
+                i--;
+                j--;
+            } else if(this.dp[i - 1][j] > this.dp[i][j - 1]) {
+                i--;
+            } else {
+                j--;
+            }
+        }
+        LCS.reverse();
+        this.lcs = LCS;
+        this.hashedlcs = hashedLCS;
     }
 
     _cleanse(str, options) {
@@ -64,6 +86,40 @@ class LineDiff {
             res.toLowerCase();
         }
         return res;
+    }
+
+    getDiffSource(keep="1", change="0") {
+        let i = 0;
+        let diff = "";
+        let j = 0;
+        while(i < this.hashedlcs.length) {
+            if(this.astr[j] === this.hashedlcs[i]) {
+                diff += keep;
+                i++;
+            } else {
+                diff += change;
+            }
+            j++;
+        }
+
+        return diff;
+    }
+
+    getDiffTarget(keep="1", change="0") {
+        let i = 0;
+        let diff = "";
+        let j = 0;
+        while(i < this.hashedlcs.length) {
+            if(this.bstr[j] === this.hashedlcs[i]) {
+                diff += keep;
+                i++;
+            } else {
+                diff += change;
+            }
+            j++;
+        }
+
+        return diff;
     }
 
 }

--- a/lib/linediff.js
+++ b/lib/linediff.js
@@ -83,3 +83,5 @@ class LineDiff {
         this.linesAdded = b.length - this.linelcs;
     }
 }
+
+module.exports = LineDiff;

--- a/lib/linediff.js
+++ b/lib/linediff.js
@@ -1,0 +1,88 @@
+const reverse = require("esrever").reverse;
+const fs = require("fs");
+const readline = require("readline");
+const crypto = require("crypto");
+
+class LineDiff {
+    constructor(a, b) { //a: "source" ReadableStream (file), b: "target" ReadableStream (file) 
+        this.a = a;
+        this.b = b;
+    }
+
+    _cleanse(str, options) {
+        const res = str;
+        if(options.ignoreWhitespace) {
+            res.replace(/\s/, "");
+        }
+        if(options.ignoreCase) {
+            res.toLowerCase();
+        }
+        return res;
+    }
+
+    load(options) { // {ignoreCase: bool, ignoreWhitespace: bool}
+        const linesA = this.a.split(/\r?\n/);
+        const linesB = this.b.split(/\r?\n/);
+
+        const astr = [];
+        const bstr = [];
+        const hashA = {};
+        const hashB = {};
+
+        for (const line of linesA) {
+            const hash = crypto.createHash("sha256");
+            const cleansed = this._cleanse(line, options);
+            if(cleansed.length < 1) continue;
+
+
+            hash.update(cleansed);
+
+            const hashed = hash.digest("base64");
+            astr.push(hashed);
+            hashA[hashed] = line;
+        }
+        
+        for (const line of linesB) {
+            const hash = crypto.createHash("sha256");
+            const cleansed = this._cleanse(line, options);
+            hash.update(cleansed);
+            if(cleansed.length < 1) continue;
+
+            const hashed = hash.digest("base64");
+            bstr.push(hashed);
+            hashB[hashed] = line;
+        }
+
+        this.astr = astr;
+        this.bstr = bstr;
+        this.hashA = hashA;
+        this.hashB = hashB;
+
+        return this;
+    }
+
+    calculate() {
+        const n = this.astr.length;
+        const m = this.bstr.length;
+        const a = this.astr;
+        const b = this.bstr;
+
+        this.dp = [...Array(n+1)].map(() => Array(m+1).fill(0));
+        for(let i = 1; i <= n; i++) {
+            for(let j = 1; j <= m; j++) {
+                if(a[i - 1] === b[j - 1]) {
+                    this.dp[i][j] = 1 + this.dp[i - 1][j - 1];
+                } else {
+                    this.dp[i][j] = Math.max(this.dp[i - 1][j], this.dp[i][j - 1]);
+                }
+            }
+        }
+
+        this.linelcs = this.dp[n][m];
+        this.linesDeleted = a.length - this.linelcs;
+        this.linesAdded = b.length - this.linelcs;
+    }
+}
+
+const e = new LineDiff(fs.readFileSync("./test.txt", { encoding: "utf-8"}), fs.readFileSync("./test2.txt", { encoding: "utf-8" })).load({ignoreCase: true, ignoreWhitespace: true});
+e.calculate();

--- a/lib/linediff.js
+++ b/lib/linediff.js
@@ -4,9 +4,55 @@ const readline = require("readline");
 const crypto = require("crypto");
 
 class LineDiff {
-    constructor(a, b) { //a: "source" ReadableStream (file), b: "target" ReadableStream (file) 
+    constructor(a, b, options) { //a: "source" ReadableStream (file), b: "target" ReadableStream (file), options: {ignoreCase: bool, ignoreWhitespace: bool}
         this.a = a;
         this.b = b;
+        const linesA = this.a.split(/\r?\n/);
+        const linesB = this.b.split(/\r?\n/);
+        const astr = [];
+        const bstr = [];
+        const hashA = {};
+        const hashB = {};
+        for (const line of linesA) {
+            const hash = crypto.createHash("sha256");
+            const cleansed = this._cleanse(line, options);
+            if(cleansed.length < 1) continue;
+            hash.update(cleansed);
+            const hashed = hash.digest("base64");
+            astr.push(hashed);
+            hashA[hashed] = line;
+        }
+        for (const line of linesB) {
+            const hash = crypto.createHash("sha256");
+            const cleansed = this._cleanse(line, options);
+            hash.update(cleansed);
+            if(cleansed.length < 1) continue;
+            const hashed = hash.digest("base64");
+            bstr.push(hashed);
+            hashB[hashed] = line;
+        }
+        this.astr = astr;
+        this.bstr = bstr;
+        this.hashA = hashA;
+        this.hashB = hashB;
+
+
+
+
+        const n = this.astr.length;
+        this.dp = [...Array(n+1)].map(() => Array(m+1).fill(0));
+        for(let i = 1; i <= n; i++) {
+            for(let j = 1; j <= m; j++) {
+                if(astr[i - 1] === bstr[j - 1]) {
+                    this.dp[i][j] = 1 + this.dp[i - 1][j - 1];
+                } else {
+                    this.dp[i][j] = Math.max(this.dp[i - 1][j], this.dp[i][j - 1]);
+                }
+            }
+        }
+        this.linelcs = this.dp[n][m];
+        this.linesDeleted = a.length - this.linelcs;
+        this.linesAdded = b.length - this.linelcs;
     }
 
     _cleanse(str, options) {
@@ -20,68 +66,6 @@ class LineDiff {
         return res;
     }
 
-    load(options) { // {ignoreCase: bool, ignoreWhitespace: bool}
-        const linesA = this.a.split(/\r?\n/);
-        const linesB = this.b.split(/\r?\n/);
-
-        const astr = [];
-        const bstr = [];
-        const hashA = {};
-        const hashB = {};
-
-        for (const line of linesA) {
-            const hash = crypto.createHash("sha256");
-            const cleansed = this._cleanse(line, options);
-            if(cleansed.length < 1) continue;
-
-
-            hash.update(cleansed);
-
-            const hashed = hash.digest("base64");
-            astr.push(hashed);
-            hashA[hashed] = line;
-        }
-        
-        for (const line of linesB) {
-            const hash = crypto.createHash("sha256");
-            const cleansed = this._cleanse(line, options);
-            hash.update(cleansed);
-            if(cleansed.length < 1) continue;
-
-            const hashed = hash.digest("base64");
-            bstr.push(hashed);
-            hashB[hashed] = line;
-        }
-
-        this.astr = astr;
-        this.bstr = bstr;
-        this.hashA = hashA;
-        this.hashB = hashB;
-
-        return this;
-    }
-
-    calculate() {
-        const n = this.astr.length;
-        const m = this.bstr.length;
-        const a = this.astr;
-        const b = this.bstr;
-
-        this.dp = [...Array(n+1)].map(() => Array(m+1).fill(0));
-        for(let i = 1; i <= n; i++) {
-            for(let j = 1; j <= m; j++) {
-                if(a[i - 1] === b[j - 1]) {
-                    this.dp[i][j] = 1 + this.dp[i - 1][j - 1];
-                } else {
-                    this.dp[i][j] = Math.max(this.dp[i - 1][j], this.dp[i][j - 1]);
-                }
-            }
-        }
-
-        this.linelcs = this.dp[n][m];
-        this.linesDeleted = a.length - this.linelcs;
-        this.linesAdded = b.length - this.linelcs;
-    }
 }
 
 module.exports = LineDiff;

--- a/lib/linediff.js
+++ b/lib/linediff.js
@@ -17,7 +17,7 @@ class LineDiff {
         const hashA = {};
         const hashB = {};
         for (const line of linesA) {
-            const hash = crypto.createHash("sha256");
+            const hash = crypto.createHash("sha1");
             const cleansed = this._cleanse(line, options);
             if(cleansed.length < 1) continue;
             hash.update(cleansed);
@@ -26,7 +26,7 @@ class LineDiff {
             hashA[hashed] = line;
         }
         for (const line of linesB) {
-            const hash = crypto.createHash("sha256");
+            const hash = crypto.createHash("sha1");
             const cleansed = this._cleanse(line, options);
             hash.update(cleansed);
             if(cleansed.length < 1) continue;


### PR DESCRIPTION
**Why this should be merged**
LineDiff provides a new interface for diff-ing larger strings and files. Instead of comparing character by character, LineDiff instead runs a hash function line by line to reduce it to a fixed size digest. That digest can then be treated in the same way as a character, except it will most likely be shorter than the actual line, hence improving performance.
**Breaking changes**
None, only new methods are added. Documentation coming soon.